### PR TITLE
fix: SSRF protection + restrict server bind address

### DIFF
--- a/data_proxy.py
+++ b/data_proxy.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 import requests as http_requests
 from bs4 import BeautifulSoup
+from url_validator import validate_url, URLValidationError
 
 
 DB_PATH = "agent_proxy.db"
@@ -210,6 +211,19 @@ def estimate_tokens(text: str) -> int:
 
 def fetch_and_clean(url: str, ttl: int = 300) -> DataResult:
     """Fetch a URL, clean it, cache it, return clean content."""
+
+    # Validate URL before doing anything (SSRF protection)
+    try:
+        validate_url(url)
+    except URLValidationError as e:
+        error = str(e)
+        log_fetch(url, 0, 0, from_cache=False, error=error)
+        return DataResult(
+            url=url, original_size=0, cleaned_size=0,
+            original_tokens=0, cleaned_tokens=0,
+            from_cache=False, content="", content_type="error",
+            error=error
+        )
 
     # Check cache first
     cached = cache_get(url)

--- a/proxy.py
+++ b/proxy.py
@@ -14,6 +14,7 @@ import uuid
 from flask import Flask, request, jsonify
 from optimizer import optimize_prompt
 from data_proxy import fetch_and_clean, init_data_db
+from url_validator import validate_batch, URLValidationError
 
 app = Flask(__name__)
 
@@ -163,6 +164,11 @@ def fetch_batch():
     if not urls:
         return jsonify({"error": "Send {\"urls\": [\"https://...\", ...]}"}), 400
 
+    try:
+        validate_batch(urls)
+    except URLValidationError as e:
+        return jsonify({"error": str(e)}), 400
+
     results = []
     total_original = 0
     total_cleaned = 0
@@ -233,4 +239,4 @@ if __name__ == "__main__":
     print(f"  Running: http://localhost:{PROXY_PORT}")
     print(f"  Stats:   http://localhost:{PROXY_PORT}/stats")
     print("=" * 52 + "\n")
-    app.run(host="0.0.0.0", port=PROXY_PORT, debug=False)
+    app.run(host="127.0.0.1", port=PROXY_PORT, debug=False)

--- a/url_validator.py
+++ b/url_validator.py
@@ -1,0 +1,87 @@
+"""
+url_validator.py — SSRF protection for token-enhancer
+Rejects anything that isn't a public HTTPS URL.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+# RFC 1918 + loopback + link-local + other reserved ranges
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),      # loopback
+    ipaddress.ip_network("10.0.0.0/8"),       # RFC 1918
+    ipaddress.ip_network("172.16.0.0/12"),    # RFC 1918
+    ipaddress.ip_network("192.168.0.0/16"),   # RFC 1918
+    ipaddress.ip_network("169.254.0.0/16"),   # link-local / AWS metadata
+    ipaddress.ip_network("100.64.0.0/10"),    # Tailscale / CGNAT
+    ipaddress.ip_network("::1/128"),          # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),         # IPv6 ULA
+    ipaddress.ip_network("fe80::/10"),        # IPv6 link-local
+]
+
+# Batch hard limit
+MAX_BATCH_URLS = 10
+
+
+class URLValidationError(ValueError):
+    pass
+
+
+def validate_url(url: str) -> str:
+    """
+    Validate that a URL is a public HTTPS target.
+    Returns the URL unchanged if valid, raises URLValidationError otherwise.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise URLValidationError("URL must be a non-empty string.")
+
+    parsed = urlparse(url)
+
+    # Schema must be https
+    if parsed.scheme != "https":
+        raise URLValidationError(
+            f"Only HTTPS URLs are allowed (got scheme: '{parsed.scheme}')."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise URLValidationError("URL has no hostname.")
+
+    # Resolve hostname to IP and check against blocked ranges
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise URLValidationError(f"Cannot resolve hostname '{hostname}': {e}")
+
+    for info in infos:
+        addr_str = info[4][0]
+        try:
+            addr = ipaddress.ip_address(addr_str)
+        except ValueError:
+            continue
+        for network in _BLOCKED_NETWORKS:
+            if addr in network:
+                raise URLValidationError(
+                    f"URL resolves to a private/reserved address ({addr_str}). "
+                    "SSRF protection rejected this request."
+                )
+
+    return url
+
+
+def validate_batch(urls: list) -> list:
+    """
+    Validate a list of URLs. Raises URLValidationError on the first
+    invalid entry or if the batch exceeds MAX_BATCH_URLS.
+    """
+    if not isinstance(urls, list):
+        raise URLValidationError("'urls' must be a list.")
+    if len(urls) > MAX_BATCH_URLS:
+        raise URLValidationError(
+            f"Batch size {len(urls)} exceeds maximum of {MAX_BATCH_URLS}."
+        )
+    for url in urls:
+        validate_url(url)
+    return urls


### PR DESCRIPTION
## Summary

This PR closes two security vulnerabilities in token-enhancer:

- **SSRF (Server-Side Request Forgery)** — the `/fetch` and `/fetch/batch` endpoints previously accepted any URL, allowing an attacker to make the proxy reach internal network resources (e.g. `http://169.254.169.254/` AWS metadata, RFC 1918 hosts, loopback).
- **Network exposure** — `app.run(host="0.0.0.0")` bound the Flask server on all interfaces, unintentionally exposing it on external network interfaces.

## Changes

### `url_validator.py` (new)
- `validate_url(url)` — enforces HTTPS scheme and resolves the hostname, rejecting any address in RFC 1918, loopback (127/8, ::1), link-local (169.254/16, fe80::/10), Tailscale/CGNAT (100.64/10), or IPv6 ULA (fc00::/7).
- `validate_batch(urls)` — wraps `validate_url` for lists and enforces a hard cap of 10 URLs per batch request.
- `URLValidationError(ValueError)` — raised on any violation; callers catch it and return a 400/error response.

### `data_proxy.py`
- Imports `validate_url`, `URLValidationError` from `url_validator`.
- At the top of `fetch_and_clean()`, before the cache lookup, validates the URL and returns a `DataResult` with the error message if validation fails — preventing any network I/O against blocked targets.

### `proxy.py`
- Imports `validate_batch`, `URLValidationError` from `url_validator`.
- In `fetch_batch()`, after the empty-urls guard, calls `validate_batch(urls)` and returns HTTP 400 on failure — all URLs in a batch are validated before any are fetched.
- Changes `app.run(host="0.0.0.0", ...)` to `host="127.0.0.1"` so the server is only reachable on localhost by default.

## Test plan

- [ ] `POST /fetch` with `{"url": "http://169.254.169.254/latest/meta-data/"}` → 502 with SSRF error message
- [ ] `POST /fetch` with `{"url": "http://192.168.1.1/"}` → 502 with SSRF error message
- [ ] `POST /fetch` with `{"url": "http://example.com/"}` → 502 with "Only HTTPS" error message
- [ ] `POST /fetch` with a valid HTTPS public URL → 200 with cleaned content
- [ ] `POST /fetch/batch` with 11 URLs → 400 with batch-size error
- [ ] `POST /fetch/batch` with a private IP URL in the list → 400 before any fetch occurs
- [ ] Server no longer reachable from a remote host after the `host` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)