### PR TITLE
feat: add Dockerfile and GitHub Actions workflow for Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,10 @@
-name: Docker Build
+name: docker
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -20,29 +21,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
+      - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short,prefix=sha-
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short,prefix=sha-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /
 
 WORKDIR /app
 
-# Clone upstream repo
-RUN git clone --depth 1 --branch ${VERSION} https://github.com/Boof-Pack/token-enhancer.git /src
+# Clone upstream repo (strip 'v' prefix if present)
+RUN git clone --depth 1 --branch ${VERSION#v} https://github.com/Boof-Pack/token-enhancer.git /src
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,17 @@
 # syntax=docker/dockerfile:1
 
-ARG VERSION
+FROM python:3.12-slim
 
-FROM docker.io/library/python:3.12-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# Clone upstream repo (strip 'v' prefix if present)
-RUN git clone --depth 1 --branch ${VERSION#v} https://github.com/Boof-Pack/token-enhancer.git /src
-
-WORKDIR /src
-
-# Install dependencies
+COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Expose port
+COPY proxy.py data_proxy.py mcp_server.py optimizer.py test_all.py ./
+
 EXPOSE 8080
 
-# Run the proxy server
-CMD ["python3", "proxy.py"]
+CMD ["python", "proxy.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+ARG VERSION
+
+FROM docker.io/library/python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Clone upstream repo
+RUN git clone --depth 1 --branch ${VERSION} https://github.com/Boof-Pack/token-enhancer.git /src
+
+WORKDIR /src
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Expose port
+EXPOSE 8080
+
+# Run the proxy server
+CMD ["python3", "proxy.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 
-COPY proxy.py data_proxy.py mcp_server.py optimizer.py test_all.py ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8080
 


### PR DESCRIPTION
This PR adds a standalone Docker build setup for `token-enhancer`.

## What changed

- adds a simple `Dockerfile` that builds directly from this repo's source
- adds a GitHub Actions workflow that:
  - builds on every pull request
  - builds and pushes on every push to `main`
  - publishes `latest` on `main`
  - publishes `sha-<commit>` tags for traceability

## Why this version

This repo is standalone, so the build logic should be standalone too:
- no dependency on external repos during image build
- no tag/version plumbing required just to build
- no carry-over assumptions from `joryirving/containers`

## Related

Closes #2
